### PR TITLE
feat: merkle streamer

### DIFF
--- a/packages/merkle-streamer/.eslintrc.yml
+++ b/packages/merkle-streamer/.eslintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - "../../.eslintrc.base.yml"

--- a/packages/merkle-streamer/LICENSE.md
+++ b/packages/merkle-streamer/LICENSE.md
@@ -1,0 +1,125 @@
+GNU LESSER GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+
+Copyright (C) 2022 Sablier Labs Ltd. Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU
+General Public License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to
+version 3 of the GNU General Public License.
+
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined
+below.
+
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on
+the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by
+the Library.
+
+A "Combined Work" is a work produced by combining or linking an Application with the Library. The particular version of
+the Library with which the Combined Work was made is also called the "Linked Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding
+any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not
+on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application,
+including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the
+System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied
+by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may
+convey a copy of the modified version:
+
+a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not
+supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful,
+or
+
+b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+
+The object code form of an Application may incorporate material from a header file that is part of the Library. You may
+convey such object code under terms of your choice, provided that, if the incorporated material is not limited to
+numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or
+fewer lines in length), you do both of the following:
+
+a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its
+use are covered by this License.
+
+b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification
+of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications,
+if you also do each of the following:
+
+a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its
+use are covered by this License.
+
+b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+
+c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library
+among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+
+d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+e) Provide Installation Information, but only if you would otherwise be required to provide such information under
+section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified
+version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked
+Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and
+Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner
+specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+
+You may place library facilities that are a work based on the Library side by side in a single library together with
+other library facilities that are not Applications and are not covered by this License, and convey such a combined
+library under terms of your choice, if you do both of the following:
+
+a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library
+facilities, conveyed under the terms of this License.
+
+b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where
+to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time
+to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new
+problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain
+numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that published version or of any later version published by the Free
+Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General
+Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software
+Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General
+Public License shall apply, that proxy's public statement of acceptance of any version is permanent authorization for
+you to choose that version for the Library.

--- a/packages/merkle-streamer/README.md
+++ b/packages/merkle-streamer/README.md
@@ -1,0 +1,3 @@
+# Sablier V2 Subgraphs - Merkle Streamer
+
+See the Sablier V2 Subgraphs documentation [here](https://docs.sablier.com/api/subgraphs/overview).

--- a/packages/merkle-streamer/abis/ERC20.json
+++ b/packages/merkle-streamer/abis/ERC20.json
@@ -1,0 +1,217 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/packages/merkle-streamer/abis/ERC20Bytes.json
+++ b/packages/merkle-streamer/abis/ERC20Bytes.json
@@ -1,0 +1,217 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/packages/merkle-streamer/abis/SablierV2MerkleStreamerFactory.json
+++ b/packages/merkle-streamer/abis/SablierV2MerkleStreamerFactory.json
@@ -1,0 +1,187 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract ISablierV2MerkleStreamerLL",
+        "name": "merkleStreamer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract ISablierV2LockupLinear",
+        "name": "lockupLinear",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IERC20",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint40",
+        "name": "expiration",
+        "type": "uint40"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint40",
+            "name": "cliff",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint40",
+            "name": "total",
+            "type": "uint40"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct LockupLinear.Durations",
+        "name": "streamDurations",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "cancelable",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "transferable",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "ipfsCID",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "aggregateAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "recipientsCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "CreateMerkleStreamerLL",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "initialAdmin",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ISablierV2LockupLinear",
+        "name": "lockupLinear",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "merkleRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint40",
+        "name": "expiration",
+        "type": "uint40"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint40",
+            "name": "cliff",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint40",
+            "name": "total",
+            "type": "uint40"
+          }
+        ],
+        "internalType": "struct LockupLinear.Durations",
+        "name": "streamDurations",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bool",
+        "name": "cancelable",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "transferable",
+        "type": "bool"
+      },
+      {
+        "internalType": "string",
+        "name": "ipfsCID",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "aggregateAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "recipientsCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "createMerkleStreamerLL",
+    "outputs": [
+      {
+        "internalType": "contract ISablierV2MerkleStreamerLL",
+        "name": "merkleStreamerLL",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      }
+    ],
+    "name": "getMerkleStreamers",
+    "outputs": [
+      {
+        "internalType": "contract ISablierV2MerkleStreamer[]",
+        "name": "merkleStreamers",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/merkle-streamer/abis/SablierV2MerkleStreamerFactory.json
+++ b/packages/merkle-streamer/abis/SablierV2MerkleStreamerFactory.json
@@ -58,12 +58,6 @@
       },
       {
         "indexed": false,
-        "internalType": "bool",
-        "name": "transferable",
-        "type": "bool"
-      },
-      {
-        "indexed": false,
         "internalType": "string",
         "name": "ipfsCID",
         "type": "string"
@@ -131,11 +125,6 @@
       {
         "internalType": "bool",
         "name": "cancelable",
-        "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "transferable",
         "type": "bool"
       },
       {

--- a/packages/merkle-streamer/abis/SablierV2MerkleStreamerLL.json
+++ b/packages/merkle-streamer/abis/SablierV2MerkleStreamerLL.json
@@ -1,0 +1,405 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "initialAdmin",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ISablierV2LockupLinear",
+        "name": "lockupLinear_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "asset_",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "merkleRoot_",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint40",
+        "name": "expiration_",
+        "type": "uint40"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint40",
+            "name": "cliff",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint40",
+            "name": "total",
+            "type": "uint40"
+          }
+        ],
+        "internalType": "struct LockupLinear.Durations",
+        "name": "streamDurations_",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bool",
+        "name": "cancelable_",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "transferable_",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "CallerNotAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "currentTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint40",
+        "name": "expiration",
+        "type": "uint40"
+      }
+    ],
+    "name": "SablierV2MerkleStreamer_CampaignExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "currentTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint40",
+        "name": "expiration",
+        "type": "uint40"
+      }
+    ],
+    "name": "SablierV2MerkleStreamer_CampaignNotExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SablierV2MerkleStreamer_InvalidProof",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "SablierV2MerkleStreamer_StreamClaimed",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "streamId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claim",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      }
+    ],
+    "name": "Clawback",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "TransferAdmin",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "asset",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cancelable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claim",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "streamId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      }
+    ],
+    "name": "clawback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "expiration",
+    "outputs": [
+      {
+        "internalType": "uint40",
+        "name": "",
+        "type": "uint40"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "hasClaimed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hasExpired",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lockupLinear",
+    "outputs": [
+      {
+        "internalType": "contract ISablierV2LockupLinear",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "merkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "streamDurations",
+    "outputs": [
+      {
+        "internalType": "uint40",
+        "name": "cliff",
+        "type": "uint40"
+      },
+      {
+        "internalType": "uint40",
+        "name": "total",
+        "type": "uint40"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "transferAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "transferable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/merkle-streamer/abis/SablierV2MerkleStreamerLL.json
+++ b/packages/merkle-streamer/abis/SablierV2MerkleStreamerLL.json
@@ -47,11 +47,6 @@
         "internalType": "bool",
         "name": "cancelable_",
         "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "transferable_",
-        "type": "bool"
       }
     ],
     "stateMutability": "nonpayable",
@@ -387,19 +382,6 @@
     "name": "transferAdmin",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "transferable",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/packages/merkle-streamer/package.json
+++ b/packages/merkle-streamer/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@sablier/v2-subgraphs-merkle-streamer",
+  "description": "Sablier V2 merkle streamer subgraph",
+  "version": "1.0.0",
+  "author": {
+    "name": "Sablier Labs Ltd",
+    "url": "https://sablier.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sablier-labs/v2-subgraphs/issues"
+  },
+  "dependencies": {
+    "babel-polyfill": "^6.26.0",
+    "babel-register": "^6.26.0"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "^0.55.0",
+    "@graphprotocol/graph-ts": "^0.31.0",
+    "@trivago/prettier-plugin-sort-imports": "4.1.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.11",
+    "@typescript-eslint/parser": "^5.59.11",
+    "eslint": "^8.25.0",
+    "eslint-config-prettier": "^8.5.0",
+    "mustache": "^4.2.0",
+    "prettier": "^2.8.8",
+    "rimraf": "^3.0.2",
+    "typescript": "5.1.3"
+  },
+  "homepage": "https://github.com/sablier-labs/v2-subgraphs#readme",
+  "license": "LGPL-3.0",
+  "packageManager": "yarn@3.2.2",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sablier-labs/v2-subgraphs.git"
+  },
+  "config": {
+    "dir_chains": "src/constants/chains",
+    "dir_generated": "src/generated",
+    "flags_deploy": "--ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "flags_lint": "--ignore-path ../../.eslintignore .",
+    "flags_prettier": "--config ../../.prettierrc.yml --ignore-path ../../.prettierignore"
+  },
+  "scripts": {
+    "build": "graph build",
+    "clean": "rimraf tsconfig.tsbuildinfo subgraph.yaml",
+    "clean-modules": "rimraf node_modules",
+    "clean-generated": "rimraf $npm_package_config_dir_generated",
+    "codegen": "graph codegen --output-dir $npm_package_config_dir_generated/types/",
+    "deploy": "graph deploy $npm_package_config_flags_deploy sablier-labs/$NAME",
+    "deploy:goerli": "CHAIN=goerli yarn setup && NAME=sablier-v2-ms-goerli yarn deploy",
+    "lint-check": "eslint --ignore-path ../../.eslintignore .",
+    "lint-fix": "eslint --fix --ignore-path ../../.eslintignore .",
+    "prettier-check": "yarn prettier $npm_package_config_flags_prettier --check .",
+    "prettier-fix": "yarn prettier $npm_package_config_flags_prettier --loglevel warn --write .",
+    "setup": "yarn clean && yarn template && yarn codegen",
+    "setup:goerli": "yarn clean-generated && CHAIN=goerli yarn setup",
+    "template": "yarn template-chain && yarn template-subgraph && yarn template-env",
+    "template-chain": "tsc $npm_package_config_dir_chains/$CHAIN.ts --outDir $npm_package_config_dir_generated",
+    "template-subgraph": "mustache $npm_package_config_dir_generated/$CHAIN.js subgraph.template.yaml > subgraph.yaml",
+    "template-env": "cp $npm_package_config_dir_chains/$CHAIN.ts $npm_package_config_dir_generated/env.ts"
+  }
+}

--- a/packages/merkle-streamer/schema.graphql
+++ b/packages/merkle-streamer/schema.graphql
@@ -1,0 +1,65 @@
+enum CampaignCategory {
+  LockupDynamic
+  LockupLinear
+}
+
+type Asset @entity(immutable: true) {
+  "unique identifier resolving to the ERC20 asset/token address"
+  id: ID!
+
+  "address of the ERC20 asset/token"
+  address: Bytes!
+  "hardcoded chain id"
+  chainId: BigInt!
+  "decimals of the ERC20 asset/token"
+  decimals: BigInt!
+  "name of the ERC20 asset/token"
+  name: String!
+  "symbol of the ERC20 asset/token"
+  symbol: String!
+
+  "campaigns that rely on this asset/token"
+  campaigns: [Campaign!]! @derivedFrom(field: "asset")
+}
+
+type Campaign @entity {
+  "unique identifier resolving to contract address"
+  id: String!
+
+  "address of the campaign"
+  address: Bytes!
+  "underlying asset"
+  asset: Asset!
+  "category of campaign e.g. LockupLinear or LockupDynamic"
+  category: CampaignCategory!
+  "factory producing the campaign"
+  factory: Factory!
+}
+
+type Factory @entity {
+  "unique identifier resolving to contract address"
+  id: String!
+
+  "hardcoded alias, resolved by replacing the contract address from the id with the contract alias"
+  alias: String!
+  "address of the contract"
+  address: Bytes!
+  "address of the contract admin"
+  admin: Bytes
+
+  "list of campaigns"
+  campaigns: [Campaign!]! @derivedFrom(field: "factory")
+}
+
+type Watcher @entity {
+  "unique identifier for the watcher - there is only one watcher for the entire subgraph"
+  id: String!
+  "hardcoded chain id"
+  chainId: BigInt!
+  "global index for campaigns"
+  campaignIndex: BigInt!
+  "flag that defines the initialization status of the subgraph"
+  initialized: Boolean!
+  "list of logs, for debugging purposes"
+  logs: [String!]!
+}

--- a/packages/merkle-streamer/schema.graphql
+++ b/packages/merkle-streamer/schema.graphql
@@ -87,6 +87,8 @@ type Campaign @entity {
   hash: Bytes!
   "timestamp of the campaign creation (for sorting reasons)"
   timestamp: BigInt!
+  "category of the produced streams e.g. LockupLinear or LockupDynamic"
+  category: CampaignCategory!
 
   "address of the campaign admin, entitled to clawback"
   admin: Bytes!
@@ -111,8 +113,6 @@ type Campaign @entity {
   "timestamp for the when the campaign underwent a clawback"
   clawbackTime: BigInt
 
-  "category of the produced streams e.g. LockupLinear or LockupDynamic"
-  streamCategory: CampaignCategory!
   "flag showing if the produced stream has a cliff, only available on linear streams"
   streamCliff: Boolean!
   "timestamp for the start of the cliff, if there's a streamCliff, only available on linear streams"

--- a/packages/merkle-streamer/schema.graphql
+++ b/packages/merkle-streamer/schema.graphql
@@ -35,7 +35,7 @@ type Action @entity {
   "claim action data: stream identifier as constructed in the protocol subgraph - origin contract address concatenated with the chainId and the tokenId"
   claimStreamId: String
   "claim action data: native stream id"
-  claimTokenId: String
+  claimTokenId: BigInt
   "claim action data: amount"
   claimAmount: BigInt
   "claim action data: recipient index"
@@ -68,12 +68,10 @@ type Asset @entity(immutable: true) {
 
   "campaigns that rely on this asset/token"
   campaigns: [Campaign!]! @derivedFrom(field: "asset")
-  "list of daily activity snapshots for days with 1+ events"
-  activities: [Activity!] @derivedFrom(field: "campaign")
 }
 
 type Campaign @entity {
-  "unique identifier resolving to contract address"
+  "unique identifier resolving to the contract address concatenated with the chain id"
   id: String!
   "unique global id tracked by the subgraph watcher"
   subgraphId: BigInt!
@@ -83,13 +81,19 @@ type Campaign @entity {
   asset: Asset!
   "factory producing the campaign"
   factory: Factory!
+  "hardcoded chain id"
+  chainId: BigInt!
+  "transaction hash for the campaign creation"
+  hash: Bytes!
+  "timestamp of the campaign creation (for sorting reasons)"
+  timestamp: BigInt!
 
   "address of the campaign admin, entitled to clawback"
   admin: Bytes!
   "address of the lockup contract through which streams will be created"
   lockup: Bytes!
   "merkle root"
-  root: Bytes!
+  root: Bytes # TO DO extract this from input parameters
   "flag showing if the campaign expires or is forever claimable"
   expires: Boolean!
   "time at which the campaign expires and clawback is enabled, if the expires flag is true"
@@ -118,8 +122,15 @@ type Campaign @entity {
   "flag showing the cancelability of the produced streams (making it false is a one-way trip)"
   streamCancelable: Boolean!
 
+  "total claimed amount up to this point"
+  claimedAmount: BigInt!
+  "number of claims requested up to this point"
+  claimedCount: BigInt!
+
   "actions triggered in the context of this campaign"
   actions: [Action!]! @derivedFrom(field: "campaign")
+  "list of daily activity snapshots for days with 1+ events"
+  activities: [Activity!]! @derivedFrom(field: "campaign")
 }
 
 type Factory @entity {
@@ -130,15 +141,13 @@ type Factory @entity {
   alias: String!
   "address of the contract"
   address: Bytes!
-  "address of the contract admin"
-  admin: Bytes
 
   "list of campaigns"
   campaigns: [Campaign!]! @derivedFrom(field: "factory")
 }
 
 type Activity @entity {
-  "unique identifier resolving to the string 'activity' concatenated with the day of the snapshot"
+  "unique identifier resolving to the string 'activity' concatenated with the campaign address and the day of the snapshot"
   id: ID!
   "campaign the activity (day) is linked to"
   campaign: Campaign!

--- a/packages/merkle-streamer/schema.graphql
+++ b/packages/merkle-streamer/schema.graphql
@@ -95,18 +95,18 @@ type Campaign @entity {
   "address of the lockup contract through which streams will be created"
   lockup: Bytes!
   "merkle root"
-  root: Bytes # TO DO extract this from input parameters
+  root: Bytes!
   "flag showing if the campaign expires or is forever claimable"
   expires: Boolean!
   "time at which the campaign expires and clawback is enabled, if the expires flag is true"
   expiration: BigInt
 
   "ipfs content identifier for the list of recipients and other static details"
-  ipfsCID: String
+  ipfsCID: String!
   "funds required for the entire campaign to conclude"
-  expectedAmount: BigInt
+  expectedAmount: BigInt!
   "number of recipients"
-  expectedRecipients: BigInt
+  expectedRecipients: BigInt!
 
   "action in which the campaign underwent a clawback, if it was supposed to expire"
   clawbackAction: Action

--- a/packages/merkle-streamer/schema.graphql
+++ b/packages/merkle-streamer/schema.graphql
@@ -1,6 +1,54 @@
+enum ActionCategory {
+  Claim
+  Clawback
+  Create
+  TransferAdmin
+}
+
 enum CampaignCategory {
   LockupDynamic
   LockupLinear
+}
+
+type Action @entity {
+  "unique identifier resolving to transaction hash concatenated with the log index (there may be multiple actions per tx)"
+  id: ID!
+
+  "transaction details: block number"
+  block: BigInt!
+  "category of action e.g. Create or Clawback"
+  category: ActionCategory!
+  "hardcoded chain id"
+  chainId: BigInt!
+  "contract through which the stream actions has been triggered"
+  campaign: Campaign!
+  "transaction details: hash"
+  hash: Bytes!
+  "address that triggered the transaction"
+  from: Bytes!
+
+  "unique global id tracked by the subgraph watcher"
+  subgraphId: BigInt!
+  "transaction details: timestamp"
+  timestamp: BigInt!
+
+  "claim action data: stream identifier as constructed in the protocol subgraph - origin contract address concatenated with the chainId and the tokenId"
+  claimStreamId: String
+  "claim action data: native stream id"
+  claimTokenId: String
+  "claim action data: amount"
+  claimAmount: BigInt
+  "claim action data: recipient index"
+  claimIndex: BigInt
+  "claim action data: recipient index"
+  claimRecipient: Bytes
+
+  "clawback action data: amount"
+  clawbackAmount: BigInt
+  "clawback action data: amount"
+  clawbackFrom: Bytes
+  "clawback action data: amount"
+  clawbackTo: Bytes
 }
 
 type Asset @entity(immutable: true) {
@@ -20,20 +68,58 @@ type Asset @entity(immutable: true) {
 
   "campaigns that rely on this asset/token"
   campaigns: [Campaign!]! @derivedFrom(field: "asset")
+  "list of daily activity snapshots for days with 1+ events"
+  activities: [Activity!] @derivedFrom(field: "campaign")
 }
 
 type Campaign @entity {
   "unique identifier resolving to contract address"
   id: String!
-
+  "unique global id tracked by the subgraph watcher"
+  subgraphId: BigInt!
   "address of the campaign"
   address: Bytes!
   "underlying asset"
   asset: Asset!
-  "category of campaign e.g. LockupLinear or LockupDynamic"
-  category: CampaignCategory!
   "factory producing the campaign"
   factory: Factory!
+
+  "address of the campaign admin, entitled to clawback"
+  admin: Bytes!
+  "address of the lockup contract through which streams will be created"
+  lockup: Bytes!
+  "merkle root"
+  root: Bytes!
+  "flag showing if the campaign expires or is forever claimable"
+  expires: Boolean!
+  "time at which the campaign expires and clawback is enabled, if the expires flag is true"
+  expiration: BigInt
+
+  "ipfs content identifier for the list of recipients and other static details"
+  ipfsCID: String
+  "funds required for the entire campaign to conclude"
+  expectedAmount: BigInt
+  "number of recipients"
+  expectedRecipients: BigInt
+
+  "action in which the campaign underwent a clawback, if it was supposed to expire"
+  clawbackAction: Action
+  "timestamp for the when the campaign underwent a clawback"
+  clawbackTime: BigInt
+
+  "category of the produced streams e.g. LockupLinear or LockupDynamic"
+  streamCategory: CampaignCategory!
+  "flag showing if the produced stream has a cliff, only available on linear streams"
+  streamCliff: Boolean!
+  "timestamp for the start of the cliff, if there's a streamCliff, only available on linear streams"
+  streamCliffDuration: BigInt
+  "total duration for produced streams"
+  streamTotalDuration: BigInt!
+  "flag showing the cancelability of the produced streams (making it false is a one-way trip)"
+  streamCancelable: Boolean!
+
+  "actions triggered in the context of this campaign"
+  actions: [Action!]! @derivedFrom(field: "campaign")
 }
 
 type Factory @entity {
@@ -51,11 +137,30 @@ type Factory @entity {
   campaigns: [Campaign!]! @derivedFrom(field: "factory")
 }
 
+type Activity @entity {
+  "unique identifier resolving to the string 'activity' concatenated with the day of the snapshot"
+  id: ID!
+  "campaign the activity (day) is linked to"
+  campaign: Campaign!
+
+  "timestamp for the start of the day"
+  timestamp: BigInt!
+  "day index (UNIX time / 24 * 60 * 60)"
+  day: BigInt!
+
+  "amount claimed during the day"
+  amount: BigInt!
+  "number of claims completed during the day"
+  claims: BigInt!
+}
+
 type Watcher @entity {
   "unique identifier for the watcher - there is only one watcher for the entire subgraph"
   id: String!
   "hardcoded chain id"
   chainId: BigInt!
+  "global index for actions"
+  actionIndex: BigInt!
   "global index for campaigns"
   campaignIndex: BigInt!
   "flag that defines the initialization status of the subgraph"

--- a/packages/merkle-streamer/src/constants/chains/goerli.ts
+++ b/packages/merkle-streamer/src/constants/chains/goerli.ts
@@ -1,0 +1,21 @@
+export let chainId = 5;
+export let chain = "goerli";
+export let startBlock = 9739245;
+
+/** Rule: keep addresses lowercased" */
+
+/**
+ * Keep aliases unique and always in sync with the frontend
+ * @example export let factory = [[address1, alias2], [address2, alias2]]
+ */
+
+export let factory: string[][] = [
+  ["0x680fa6db3896ffed19448f71592bd0b6b7aaf762", "MSF"],
+];
+
+/**
+ * The initializer contract is used to trigger the indexing of all other contracts.
+ * It should be a linear contract, the oldest/first one deployed on this chain.
+ */
+
+export let initializer = factory[0][0];

--- a/packages/merkle-streamer/src/constants/chains/goerli.ts
+++ b/packages/merkle-streamer/src/constants/chains/goerli.ts
@@ -1,6 +1,6 @@
 export let chainId = 5;
 export let chain = "goerli";
-export let startBlock = 9739245;
+export let startBlock = 9819750;
 
 /** Rule: keep addresses lowercased" */
 
@@ -10,7 +10,7 @@ export let startBlock = 9739245;
  */
 
 export let factory: string[][] = [
-  ["0x680fa6db3896ffed19448f71592bd0b6b7aaf762", "MSF"],
+  ["0xeaaa45A64012F8d002D839DED9f045d44D9E7E85", "MSF"],
 ];
 
 /**

--- a/packages/merkle-streamer/src/constants/index.ts
+++ b/packages/merkle-streamer/src/constants/index.ts
@@ -30,3 +30,6 @@ export function getContractsFactory(): string[][] {
 export function getChainId(): BigInt {
   return BigInt.fromI32(chainId);
 }
+
+export const ABI_CREATE_MERKLE_STREAMER_LL =
+  "(address,address,address,bytes32,uint40,(uint40,uint40),bool,string,uint256,uint256)";

--- a/packages/merkle-streamer/src/constants/index.ts
+++ b/packages/merkle-streamer/src/constants/index.ts
@@ -1,0 +1,32 @@
+import { BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { chainId, factory, initializer } from "../generated/env";
+
+export let zero = BigInt.fromI32(0);
+export let one = BigInt.fromI32(1);
+export let two = BigInt.fromI32(2);
+export let d18 = BigInt.fromI32(18);
+
+export let put = 0;
+export let call = 1;
+
+export let ADDRESS_ZERO = Bytes.fromHexString(
+  "0x0000000000000000000000000000000000000000",
+);
+
+export function getContractInitializer(): string {
+  return initializer.toLowerCase();
+}
+
+export function getContractsFactory(): string[][] {
+  if (factory.length === 0) {
+    return [];
+  }
+  return factory.map<string[]>((item) => [
+    item[0].toString().toLowerCase(),
+    item[1].toString().toLowerCase(),
+  ]);
+}
+
+export function getChainId(): BigInt {
+  return BigInt.fromI32(chainId);
+}

--- a/packages/merkle-streamer/src/constants/index.ts
+++ b/packages/merkle-streamer/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import { chainId, factory, initializer } from "../generated/env";
 
 export let zero = BigInt.fromI32(0);
@@ -33,3 +33,9 @@ export function getChainId(): BigInt {
 
 export const ABI_CREATE_MERKLE_STREAMER_LL =
   "(address,address,address,bytes32,uint40,(uint40,uint40),bool,string,uint256,uint256)";
+
+export function log_exit(message: string, dependencies: string[] = []): void {
+  log.debug(`[SABLIER] ${message}`, dependencies);
+  log.error(`[SABLIER] ${message}`, dependencies);
+  // log.critical("[SABLIER] Critical exit.", []);
+}

--- a/packages/merkle-streamer/src/helpers/action.ts
+++ b/packages/merkle-streamer/src/helpers/action.ts
@@ -1,0 +1,48 @@
+import { dataSource, ethereum, log } from "@graphprotocol/graph-ts";
+import { Action } from "../generated/types/schema";
+import { getChainId, one } from "../constants";
+import { getCampaignById } from "./campaign";
+import { getOrCreateWatcher } from "./watcher";
+
+export function generateActionId(event: ethereum.Event): string {
+  return ""
+    .concat(event.transaction.hash.toHexString())
+    .concat("-")
+    .concat(event.logIndex.toString());
+}
+
+export function getActionById(id: string): Action | null {
+  return Action.load(id);
+}
+
+export function createAction(event: ethereum.Event): Action | null {
+  let watcher = getOrCreateWatcher();
+  let id = generateActionId(event);
+  let entity = new Action(id);
+
+  entity.block = event.block.number;
+  entity.from = event.transaction.from;
+  entity.hash = event.transaction.hash;
+  entity.timestamp = event.block.timestamp;
+  entity.subgraphId = watcher.actionIndex;
+  entity.chainId = getChainId();
+
+  /** --------------- */
+  let campaign = getCampaignById(dataSource.address().toHexString());
+  if (campaign == null) {
+    log.info(
+      "[SABLIER] Campaign hasn't been registered before this clawback event: {}",
+      [id],
+    );
+    log.error("[SABLIER]", []);
+    return null;
+  }
+
+  entity.campaign = campaign.id;
+
+  /** --------------- */
+  watcher.actionIndex = watcher.actionIndex.plus(one);
+  watcher.save();
+
+  return entity;
+}

--- a/packages/merkle-streamer/src/helpers/action.ts
+++ b/packages/merkle-streamer/src/helpers/action.ts
@@ -32,17 +32,19 @@ export function createAction(
   entity.chainId = getChainId();
 
   /** --------------- */
-  let campaignId = generateCampaignId(dataSource.address());
-  let campaign = getCampaignById(campaignId);
-  if (campaign == null) {
-    log_exit(
-      "Campaign hasn't been registered before this action event: action={}, campaign=",
-      [id, campaignId],
-    );
-    return null;
-  }
+  if (category !== "Create") {
+    let campaignId = generateCampaignId(dataSource.address());
+    let campaign = getCampaignById(campaignId);
+    if (campaign == null) {
+      log_exit(
+        "Campaign hasn't been registered before this action event: action={}, campaign=",
+        [id, campaignId],
+      );
+      return null;
+    }
 
-  entity.campaign = campaign.id;
+    entity.campaign = campaign.id;
+  }
 
   /** --------------- */
   watcher.actionIndex = watcher.actionIndex.plus(one);

--- a/packages/merkle-streamer/src/helpers/activity.ts
+++ b/packages/merkle-streamer/src/helpers/activity.ts
@@ -1,0 +1,54 @@
+import { BigInt, ethereum, log } from "@graphprotocol/graph-ts";
+import { Activity } from "../generated/types/schema";
+import { zero } from "../constants";
+import { getCampaignById } from "./campaign";
+
+export function generateActivityId(campaignId: string, day: string): string {
+  return ""
+    .concat("activity")
+    .concat("-")
+    .concat(campaignId)
+    .concat("-")
+    .concat(day);
+}
+
+export function getActivityById(id: string): Activity | null {
+  return Activity.load(id);
+}
+
+export function getOrCreateActivity(
+  campaignId: string,
+  event: ethereum.Event,
+): Activity | null {
+  let timestamp = event.block.timestamp.toI32();
+  let day = timestamp / (60 * 60 * 24);
+
+  /** --------------- */
+  let campaign = getCampaignById(campaignId);
+  if (campaign == null) {
+    log.info(
+      "[SABLIER] Campaign hasn't been registered before this activity update: {}",
+      [campaignId],
+    );
+    log.error("[SABLIER]", []);
+    return null;
+  }
+
+  /** --------------- */
+
+  let id = generateActivityId(campaignId, day.toString());
+  let entity = getActivityById(id);
+
+  if (entity != null) {
+    return entity;
+  }
+
+  entity = new Activity(id);
+  entity.day = BigInt.fromI32(day);
+  entity.campaign = campaign.id;
+
+  entity.amount = zero;
+  entity.claims = zero;
+
+  return entity;
+}

--- a/packages/merkle-streamer/src/helpers/activity.ts
+++ b/packages/merkle-streamer/src/helpers/activity.ts
@@ -1,6 +1,6 @@
-import { BigInt, ethereum, log } from "@graphprotocol/graph-ts";
+import { BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { Activity } from "../generated/types/schema";
-import { zero } from "../constants";
+import { log_exit, zero } from "../constants";
 import { getCampaignById } from "./campaign";
 
 export function generateActivityId(campaignId: string, day: string): string {
@@ -26,11 +26,10 @@ export function getOrCreateActivity(
   /** --------------- */
   let campaign = getCampaignById(campaignId);
   if (campaign == null) {
-    log.info(
-      "[SABLIER] Campaign hasn't been registered before this activity update: {}",
+    log_exit(
+      "Campaign hasn't been registered before this activity update: {}",
       [campaignId],
     );
-    log.error("[SABLIER]", []);
     return null;
   }
 
@@ -46,6 +45,7 @@ export function getOrCreateActivity(
   entity = new Activity(id);
   entity.day = BigInt.fromI32(day);
   entity.campaign = campaign.id;
+  entity.timestamp = event.block.timestamp;
 
   entity.amount = zero;
   entity.claims = zero;

--- a/packages/merkle-streamer/src/helpers/asset.ts
+++ b/packages/merkle-streamer/src/helpers/asset.ts
@@ -1,0 +1,65 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { Asset } from "../generated/types/schema";
+import { ERC20 as ERC20Contract } from "../generated/types/templates/ContractMerkleStreamerFactory/ERC20";
+import { ERC20Bytes as ERC20BytesContract } from "../generated/types/templates/ContractMerkleStreamerFactory/ERC20Bytes";
+import { getChainId } from "../constants";
+
+export function getOrCreateAsset(address: Address): Asset {
+  let id = address.toHexString();
+  let entity = Asset.load(id);
+
+  if (entity == null) {
+    entity = new Asset(address.toHexString());
+
+    let contract = ERC20Contract.bind(address);
+    let decimals = contract.decimals();
+    let name = getAssetName(address);
+    let symbol = getAssetSymbol(address);
+
+    entity.chainId = getChainId();
+    entity.address = address;
+    entity.symbol = symbol;
+    entity.name = name;
+    entity.decimals = BigInt.fromI32(decimals);
+
+    entity.save();
+  }
+
+  return entity;
+}
+
+function getAssetSymbol(address: Address): string {
+  let contract = ERC20Contract.bind(address);
+  let symbol = contract.try_symbol();
+
+  if (symbol.reverted) {
+    let contractBytes = ERC20BytesContract.bind(address);
+    let symbolBytes = contractBytes.try_symbol();
+
+    if (symbolBytes.reverted) {
+      return "Unknown";
+    } else {
+      return symbolBytes.value.toString();
+    }
+  } else {
+    return symbol.value;
+  }
+}
+
+function getAssetName(address: Address): string {
+  let contract = ERC20Contract.bind(address);
+  let name = contract.try_name();
+
+  if (name.reverted) {
+    let contractBytes = ERC20BytesContract.bind(address);
+    let nameBytes = contractBytes.try_name();
+
+    if (nameBytes.reverted) {
+      return "Unknown";
+    } else {
+      return nameBytes.value.toString();
+    }
+  } else {
+    return name.value;
+  }
+}

--- a/packages/merkle-streamer/src/helpers/campaign.ts
+++ b/packages/merkle-streamer/src/helpers/campaign.ts
@@ -1,15 +1,10 @@
-import {
-  Address,
-  ByteArray,
-  Bytes,
-  ethereum,
-  log,
-} from "@graphprotocol/graph-ts";
+import { Address, ByteArray, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import { Campaign } from "../generated/types/schema";
 import { CreateMerkleStreamerLL as EventCreateCampaignLL } from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerFactory";
 import {
   ABI_CREATE_MERKLE_STREAMER_LL,
   getChainId,
+  log_exit,
   one,
   zero,
 } from "../constants";
@@ -27,7 +22,7 @@ export function createCampaignLinear(
   let id = generateCampaignId(event.params.merkleStreamer);
   let entity = getCampaignById(id);
   if (entity != null) {
-    log.critical("[SABLIER] Campaign already registered at this address", []);
+    log_exit("Campaign already registered at this address");
     return null;
   }
 
@@ -76,7 +71,7 @@ export function createCampaignLinear(
   /** --------------- */
   let factory = getFactoryById(event.address.toHexString());
   if (factory == null) {
-    log.critical("[SABLIER] Factory not yet registered at this address", []);
+    log_exit("Factory not yet registered at this address");
     return null;
   }
   entity.factory = factory.id;

--- a/packages/merkle-streamer/src/helpers/campaign.ts
+++ b/packages/merkle-streamer/src/helpers/campaign.ts
@@ -49,7 +49,7 @@ export function createCampaignLinear(
   entity.expectedAmount = event.params.aggregateAmount;
   entity.expectedRecipients = event.params.recipientsCount;
 
-  entity.streamCategory = "LockupLinear";
+  entity.category = "LockupLinear";
   entity.streamCliff = !event.params.streamDurations.cliff.isZero();
   entity.streamCliffDuration = event.params.streamDurations.cliff;
   entity.streamTotalDuration = event.params.streamDurations.total;

--- a/packages/merkle-streamer/src/helpers/campaign.ts
+++ b/packages/merkle-streamer/src/helpers/campaign.ts
@@ -1,0 +1,89 @@
+import { Address, log } from "@graphprotocol/graph-ts";
+import { Campaign } from "../generated/types/schema";
+import { CreateMerkleStreamerLL as EventCreateCampaignLL } from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerFactory";
+import { getChainId, one, zero } from "../constants";
+import { getOrCreateAsset } from "./asset";
+import { getFactoryById } from "./factory";
+import { getOrCreateWatcher } from "./watcher";
+
+export function getCampaignById(id: string): Campaign | null {
+  return Campaign.load(id);
+}
+
+export function createCampaignLinear(
+  event: EventCreateCampaignLL,
+): Campaign | null {
+  let id = generateCampaignId(event.params.merkleStreamer);
+  let entity = getCampaignById(id);
+  if (entity != null) {
+    log.critical("[SABLIER] Campaign already registered at this address", []);
+    return null;
+  }
+
+  /** --------------- */
+  let watcher = getOrCreateWatcher();
+
+  /** --------------- */
+  entity = new Campaign(id);
+
+  entity.chainId = getChainId();
+  entity.subgraphId = watcher.campaignIndex;
+  entity.address = event.params.merkleStreamer;
+  entity.hash = event.transaction.hash;
+  entity.timestamp = event.block.timestamp;
+
+  entity.admin = event.params.admin;
+  entity.lockup = event.params.lockupLinear; // Replace when campaigns with LDs will be possible
+
+  // TO DO entity.root
+  entity.expires = !event.params.expiration.isZero();
+  entity.expiration = event.params.expiration;
+
+  entity.ipfsCID = event.params.ipfsCID;
+  entity.expectedAmount = event.params.aggregateAmount;
+  entity.expectedRecipients = event.params.recipientsCount;
+
+  entity.streamCategory = "LockupLinear";
+  entity.streamCliff = !event.params.streamDurations.cliff.isZero();
+  entity.streamCliffDuration = event.params.streamDurations.cliff;
+  entity.streamTotalDuration = event.params.streamDurations.total;
+  entity.streamCancelable = event.params.cancelable;
+
+  entity.clawbackAction = null;
+  entity.clawbackTime = null;
+
+  entity.claimedAmount = zero;
+  entity.claimedCount = zero;
+
+  /** --------------- */
+  let factory = getFactoryById(event.address.toHexString());
+  if (factory == null) {
+    log.critical("[SABLIER] Factory not yet registered at this address", []);
+    return null;
+  }
+  entity.factory = factory.id;
+
+  /** --------------- */
+  let asset = getOrCreateAsset(event.params.asset);
+  entity.asset = asset.id;
+
+  /** --------------- */
+  watcher.campaignIndex = watcher.campaignIndex.plus(one);
+  watcher.save();
+
+  /** --------------- */
+  return entity;
+}
+
+/** --------------------------------------------------------------------------------------------------------- */
+/** --------------------------------------------------------------------------------------------------------- */
+/** --------------------------------------------------------------------------------------------------------- */
+
+export function generateCampaignId(address: Address): string {
+  let id = ""
+    .concat(address.toHexString())
+    .concat("-")
+    .concat(getChainId().toString());
+
+  return id;
+}

--- a/packages/merkle-streamer/src/helpers/factory.ts
+++ b/packages/merkle-streamer/src/helpers/factory.ts
@@ -1,0 +1,20 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { Factory } from "../generated/types/schema";
+
+export function getFactoryById(id: string): Factory | null {
+  return Factory.load(id);
+}
+
+export function createFactory(address: Address, alias: string): Factory {
+  let id = address.toHexString();
+  let entity = getFactoryById(id);
+  if (entity == null) {
+    entity = new Factory(id);
+  }
+
+  entity.alias = alias;
+  entity.address = address;
+
+  entity.save();
+  return entity;
+}

--- a/packages/merkle-streamer/src/helpers/index.ts
+++ b/packages/merkle-streamer/src/helpers/index.ts
@@ -1,0 +1,5 @@
+import { getOrCreateAsset } from "./asset";
+import { createFactory, getFactoryById } from "./factory";
+import { getOrCreateWatcher } from "./watcher";
+
+export { getOrCreateAsset, getFactoryById, createFactory, getOrCreateWatcher };

--- a/packages/merkle-streamer/src/helpers/index.ts
+++ b/packages/merkle-streamer/src/helpers/index.ts
@@ -1,5 +1,25 @@
+import { createAction, generateActionId } from "./action";
+import { getOrCreateActivity } from "./activity";
 import { getOrCreateAsset } from "./asset";
+import {
+  createCampaignLinear,
+  generateCampaignId,
+  getCampaignById,
+} from "./campaign";
 import { createFactory, getFactoryById } from "./factory";
+import { generateStreamId } from "./stream";
 import { getOrCreateWatcher } from "./watcher";
 
-export { getOrCreateAsset, getFactoryById, createFactory, getOrCreateWatcher };
+export {
+  createAction,
+  createCampaignLinear,
+  createFactory,
+  generateActionId,
+  generateCampaignId,
+  generateStreamId,
+  getOrCreateActivity,
+  getCampaignById,
+  getOrCreateAsset,
+  getFactoryById,
+  getOrCreateWatcher,
+};

--- a/packages/merkle-streamer/src/helpers/stream.ts
+++ b/packages/merkle-streamer/src/helpers/stream.ts
@@ -1,0 +1,13 @@
+import { BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { getChainId } from "../constants";
+
+export function generateStreamId(contract: Bytes, tokenId: BigInt): string {
+  let id = ""
+    .concat(contract.toHexString())
+    .concat("-")
+    .concat(getChainId().toString())
+    .concat("-")
+    .concat(tokenId.toString());
+
+  return id;
+}

--- a/packages/merkle-streamer/src/helpers/watcher.ts
+++ b/packages/merkle-streamer/src/helpers/watcher.ts
@@ -1,0 +1,17 @@
+import { Watcher } from "../generated/types/schema";
+import { getChainId, one } from "../constants";
+
+export function getOrCreateWatcher(): Watcher {
+  let id = "1";
+  let entity = Watcher.load(id);
+
+  if (entity == null) {
+    entity = new Watcher(id);
+    entity.chainId = getChainId();
+    entity.campaignIndex = one;
+    entity.initialized = false;
+    entity.logs = [];
+  }
+
+  return entity;
+}

--- a/packages/merkle-streamer/src/helpers/watcher.ts
+++ b/packages/merkle-streamer/src/helpers/watcher.ts
@@ -8,6 +8,7 @@ export function getOrCreateWatcher(): Watcher {
   if (entity == null) {
     entity = new Watcher(id);
     entity.chainId = getChainId();
+    entity.actionIndex = one;
     entity.campaignIndex = one;
     entity.initialized = false;
     entity.logs = [];

--- a/packages/merkle-streamer/src/mappings/handle-campaign.ts
+++ b/packages/merkle-streamer/src/mappings/handle-campaign.ts
@@ -1,10 +1,117 @@
+import { log } from "@graphprotocol/graph-ts";
 import {
   Claim as EventClaim,
   Clawback as EventClawback,
   TransferAdmin as EventTransferAdmin,
 } from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerLL";
+import { one } from "../constants";
+import {
+  createAction,
+  generateStreamId,
+  getCampaignById,
+  getOrCreateActivity,
+} from "../helpers";
 
-export function handleClaim(_event: EventClaim): void {}
+export function handleClaim(event: EventClaim): void {
+  let action = createAction(event);
+  if (action == null) {
+    log.critical(
+      "[SABLIER] Campaign not registered yet, cannot bind action",
+      [],
+    );
+    return;
+  }
 
-export function handleClawback(_event: EventClawback): void {}
-export function handleTransferAdmin(_event: EventTransferAdmin): void {}
+  let campaign = getCampaignById(action.campaign);
+  if (campaign == null) {
+    log.critical("[SABLIER] Campaign not registered yet", []);
+    return;
+  }
+
+  /** --------------- */
+  action.category = "Claim";
+  action.claimIndex = event.params.index;
+  action.claimAmount = event.params.amount;
+  action.claimRecipient = event.params.recipient;
+  action.claimTokenId = event.params.streamId;
+  action.claimStreamId = generateStreamId(
+    campaign.lockup,
+    event.params.streamId,
+  );
+
+  /** --------------- */
+  campaign.claimedAmount = campaign.claimedAmount.plus(event.params.amount);
+  campaign.claimedCount = campaign.claimedCount.plus(one);
+  campaign.save();
+
+  /** --------------- */
+  let activity = getOrCreateActivity(campaign.id, event);
+  if (activity == null) {
+    log.critical("[SABLIER] Activity not registered yet", []);
+    return;
+  }
+
+  activity.claims = activity.claims.plus(one);
+  activity.amount = activity.amount.plus(event.params.amount);
+  activity.save();
+
+  /** --------------- */
+  action.save();
+}
+
+export function handleClawback(event: EventClawback): void {
+  let action = createAction(event);
+  if (action == null) {
+    log.critical(
+      "[SABLIER] Campaign not registered yet, cannot bind action",
+      [],
+    );
+    return;
+  }
+
+  let campaign = getCampaignById(action.campaign);
+  if (campaign == null) {
+    log.critical("[SABLIER] Campaign not registered yet", []);
+    return;
+  }
+
+  /** --------------- */
+  action.category = "Clawback";
+  action.clawbackFrom = event.params.admin;
+  action.clawbackTo = event.params.to;
+  action.clawbackAmount = event.params.amount;
+
+  /** --------------- */
+  campaign.clawbackTime = event.block.timestamp;
+  campaign.clawbackAction = action.id;
+  campaign.save();
+
+  /** --------------- */
+  action.save();
+}
+export function handleTransferAdmin(event: EventTransferAdmin): void {
+  let action = createAction(event);
+  if (action == null) {
+    log.critical(
+      "[SABLIER] Campaign not registered yet, cannot bind action",
+      [],
+    );
+    return;
+  }
+
+  let campaign = getCampaignById(action.campaign);
+  if (campaign == null) {
+    log.critical("[SABLIER] Campaign not registered yet", []);
+    return;
+  }
+
+  /** --------------- */
+  action.category = "TransferAdmin";
+
+  /** --------------- */
+  campaign.admin = event.params.newAdmin;
+  campaign.save();
+
+  /** --------------- */
+  action.save();
+}

--- a/packages/merkle-streamer/src/mappings/handle-campaign.ts
+++ b/packages/merkle-streamer/src/mappings/handle-campaign.ts
@@ -1,0 +1,10 @@
+import {
+  Claim as EventClaim,
+  Clawback as EventClawback,
+  TransferAdmin as EventTransferAdmin,
+} from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerLL";
+
+export function handleClaim(_event: EventClaim): void {}
+
+export function handleClawback(_event: EventClawback): void {}
+export function handleTransferAdmin(_event: EventTransferAdmin): void {}

--- a/packages/merkle-streamer/src/mappings/handle-factory.ts
+++ b/packages/merkle-streamer/src/mappings/handle-factory.ts
@@ -1,0 +1,3 @@
+import { CreateMerkleStreamerLL as EventCreateLinear } from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerFactory";
+
+export function handleCreateLL(_event: EventCreateLinear): void {}

--- a/packages/merkle-streamer/src/mappings/handle-factory.ts
+++ b/packages/merkle-streamer/src/mappings/handle-factory.ts
@@ -1,3 +1,13 @@
-import { CreateMerkleStreamerLL as EventCreateLinear } from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerFactory";
+import { ContractMerkleStreamerLL as ContractCampaignLL } from "../generated/types/templates";
+import { CreateMerkleStreamerLL as EventCreateCampaignLL } from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerFactory";
+import { createCampaignLinear } from "../helpers";
 
-export function handleCreateLL(_event: EventCreateLinear): void {}
+export function handleCreateCampaignLL(event: EventCreateCampaignLL): void {
+  let campaign = createCampaignLinear(event);
+  if (campaign == null) {
+    return;
+  }
+
+  ContractCampaignLL.create(event.params.merkleStreamer);
+  campaign.save();
+}

--- a/packages/merkle-streamer/src/mappings/handle-factory.ts
+++ b/packages/merkle-streamer/src/mappings/handle-factory.ts
@@ -1,6 +1,7 @@
 import { ContractMerkleStreamerLL as ContractCampaignLL } from "../generated/types/templates";
 import { CreateMerkleStreamerLL as EventCreateCampaignLL } from "../generated/types/templates/ContractMerkleStreamerFactory/SablierV2MerkleStreamerFactory";
-import { createCampaignLinear } from "../helpers";
+import { log_exit } from "../constants";
+import { createAction, createCampaignLinear } from "../helpers";
 
 export function handleCreateCampaignLL(event: EventCreateCampaignLL): void {
   let campaign = createCampaignLinear(event);
@@ -10,4 +11,12 @@ export function handleCreateCampaignLL(event: EventCreateCampaignLL): void {
 
   ContractCampaignLL.create(event.params.merkleStreamer);
   campaign.save();
+
+  let action = createAction(event, "Create");
+  if (action == null) {
+    log_exit("Campaign not registered yet, cannot bind action");
+    return;
+  }
+  action.campaign = campaign.id;
+  action.save();
 }

--- a/packages/merkle-streamer/src/mappings/handle-initializer.ts
+++ b/packages/merkle-streamer/src/mappings/handle-initializer.ts
@@ -17,8 +17,6 @@ export function handleInitializer(_event: EventCreateLinear): void {
     watcher.save();
   }
 
-  watcher.logs.push("Initialized");
-
   let factories = getContractsFactory();
   if (factories.length > 0) {
     for (let i = 0; i < factories.length; i++) {
@@ -26,9 +24,7 @@ export function handleInitializer(_event: EventCreateLinear): void {
       const alias = factories[i][1];
 
       FactoryTemplate.create(address);
-      let factory = createFactory(address, alias);
-
-      watcher.logs.push(`New factory ${factory.id}`);
+      createFactory(address, alias);
     }
   }
 }

--- a/packages/merkle-streamer/src/mappings/handle-initializer.ts
+++ b/packages/merkle-streamer/src/mappings/handle-initializer.ts
@@ -1,0 +1,34 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { CreateMerkleStreamerLL as EventCreateLinear } from "../generated/types/ContractInitializer/SablierV2MerkleStreamerFactory";
+import { ContractMerkleStreamerFactory as FactoryTemplate } from "../generated/types/templates";
+import { getContractsFactory } from "../constants";
+import { createFactory, getOrCreateWatcher } from "../helpers";
+
+/**
+ * Use the oldest linear contract as a trigger to start indexing all the other contracts.
+ */
+
+export function handleInitializer(_event: EventCreateLinear): void {
+  let watcher = getOrCreateWatcher();
+  if (watcher.initialized) {
+    return;
+  } else {
+    watcher.initialized = true;
+    watcher.save();
+  }
+
+  watcher.logs.push("Initialized");
+
+  let factories = getContractsFactory();
+  if (factories.length > 0) {
+    for (let i = 0; i < factories.length; i++) {
+      const address = Address.fromString(factories[i][0]);
+      const alias = factories[i][1];
+
+      FactoryTemplate.create(address);
+      let factory = createFactory(address, alias);
+
+      watcher.logs.push(`New factory ${factory.id}`);
+    }
+  }
+}

--- a/packages/merkle-streamer/src/mappings/index.ts
+++ b/packages/merkle-streamer/src/mappings/index.ts
@@ -1,0 +1,7 @@
+export { handleInitializer } from "./handle-initializer";
+export { handleCreateLL } from "./handle-factory";
+export {
+  handleClaim,
+  handleClawback,
+  handleTransferAdmin,
+} from "./handle-campaign";

--- a/packages/merkle-streamer/src/mappings/index.ts
+++ b/packages/merkle-streamer/src/mappings/index.ts
@@ -1,5 +1,5 @@
 export { handleInitializer } from "./handle-initializer";
-export { handleCreateLL } from "./handle-factory";
+export { handleCreateCampaignLL } from "./handle-factory";
 export {
   handleClaim,
   handleClawback,

--- a/packages/merkle-streamer/src/utils/index.ts
+++ b/packages/merkle-streamer/src/utils/index.ts
@@ -1,0 +1,19 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+import { one, zero } from "../constants";
+
+export function convertExponentToBigInt(decimals: BigInt): BigInt {
+  let base = BigInt.fromI32(1);
+  for (let i = zero; i.lt(decimals); i = i.plus(one)) {
+    base = base.times(BigInt.fromI32(10));
+  }
+  return base;
+}
+
+export function convertStringToPaddedZero(source: String): String {
+  let result = source;
+  while (result.length !== 66) {
+    result = result.concat("0");
+  }
+
+  return result;
+}

--- a/packages/merkle-streamer/subgraph.template.yaml
+++ b/packages/merkle-streamer/subgraph.template.yaml
@@ -43,6 +43,8 @@ templates:
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
+        - Action
+        - Activity
         - Asset
         - Campaign
         - Factory
@@ -60,7 +62,7 @@ templates:
         - event:
             CreateMerkleStreamerLL(address,indexed address,indexed address,indexed
             address,uint40,(uint40,uint40),bool,string,uint256,uint256)
-          handler: handleCreateLL
+          handler: handleCreateCampaignLL
       file: ./src/mappings/index.ts
   - kind: ethereum/contract
     name: ContractMerkleStreamerLL
@@ -72,6 +74,8 @@ templates:
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
+        - Action
+        - Activity
         - Asset
         - Campaign
         - Factory

--- a/packages/merkle-streamer/subgraph.template.yaml
+++ b/packages/merkle-streamer/subgraph.template.yaml
@@ -29,7 +29,7 @@ dataSources:
       eventHandlers:
         - event:
             CreateMerkleStreamerLL(address,indexed address,indexed address,indexed
-            address,uint40,(uint40,uint40),bool,bool,string,uint256,uint256)
+            address,uint40,(uint40,uint40),bool,string,uint256,uint256)
           handler: handleInitializer
       file: ./src/mappings/index.ts
 templates:
@@ -59,7 +59,7 @@ templates:
       eventHandlers:
         - event:
             CreateMerkleStreamerLL(address,indexed address,indexed address,indexed
-            address,uint40,(uint40,uint40),bool,bool,string,uint256,uint256)
+            address,uint40,(uint40,uint40),bool,string,uint256,uint256)
           handler: handleCreateLL
       file: ./src/mappings/index.ts
   - kind: ethereum/contract

--- a/packages/merkle-streamer/subgraph.template.yaml
+++ b/packages/merkle-streamer/subgraph.template.yaml
@@ -1,0 +1,95 @@
+specVersion: 0.0.5
+description: Sablier V2 Subgraph
+repository: https://github.com/sablier-labs/v2-subgraphs
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ContractInitializer
+    network: {{chain}}
+    source:
+      address: "{{initializer}}"
+      abi: SablierV2MerkleStreamerFactory
+      startBlock: {{startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Factory
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20Bytes
+          file: ./abis/ERC20Bytes.json
+        - name: SablierV2MerkleStreamerFactory
+          file: ./abis/SablierV2MerkleStreamerFactory.json
+        - name: SablierV2MerkleStreamerLL
+          file: ./abis/SablierV2MerkleStreamerLL.json
+      eventHandlers:
+        - event:
+            CreateMerkleStreamerLL(address,indexed address,indexed address,indexed
+            address,uint40,(uint40,uint40),bool,bool,string,uint256,uint256)
+          handler: handleInitializer
+      file: ./src/mappings/index.ts
+templates:
+  - kind: ethereum/contract
+    name: ContractMerkleStreamerFactory
+    network: {{chain}}
+    source:
+      abi: SablierV2MerkleStreamerFactory
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Asset
+        - Campaign
+        - Factory
+        - Watcher
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20Bytes
+          file: ./abis/ERC20Bytes.json
+        - name: SablierV2MerkleStreamerFactory
+          file: ./abis/SablierV2MerkleStreamerFactory.json
+        - name: SablierV2MerkleStreamerLL
+          file: ./abis/SablierV2MerkleStreamerLL.json
+      eventHandlers:
+        - event:
+            CreateMerkleStreamerLL(address,indexed address,indexed address,indexed
+            address,uint40,(uint40,uint40),bool,bool,string,uint256,uint256)
+          handler: handleCreateLL
+      file: ./src/mappings/index.ts
+  - kind: ethereum/contract
+    name: ContractMerkleStreamerLL
+    network: {{chain}}
+    source:
+      abi: SablierV2MerkleStreamerLL
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Asset
+        - Campaign
+        - Factory
+        - Watcher
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20Bytes
+          file: ./abis/ERC20Bytes.json
+        - name: SablierV2MerkleStreamerFactory
+          file: ./abis/SablierV2MerkleStreamerFactory.json
+        - name: SablierV2MerkleStreamerLL
+          file: ./abis/SablierV2MerkleStreamerLL.json
+      eventHandlers:
+        - event: Claim(uint256,indexed address,uint128,indexed uint256)
+          handler: handleClaim
+        - event: Clawback(indexed address,indexed address,uint128)
+          handler: handleClawback
+        - event: TransferAdmin(indexed address,indexed address)
+          handler: handleTransferAdmin
+      file: ./src/mappings/index.ts

--- a/packages/merkle-streamer/tsconfig.json
+++ b/packages/merkle-streamer/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json"
+}

--- a/packages/protocol/schema.graphql
+++ b/packages/protocol/schema.graphql
@@ -136,7 +136,7 @@ type Stream @entity {
   renounceAction: Action
   "timestamp for the when the stream was made non-cancelable"
   renounceTime: BigInt
-  "flag showing if the stream  was (making it true is a one-way trip)"
+  "flag showing if the stream was (making it true is a one-way trip)"
   canceled: Boolean!
   "action in which the stream was"
   canceledAction: Action

--- a/packages/protocol/src/mappings/handle-stream.ts
+++ b/packages/protocol/src/mappings/handle-stream.ts
@@ -14,7 +14,6 @@ import { one, zero } from "../constants";
 import {
   createAction,
   getContractById,
-  getOrCreateWatcher,
   getStreamByIdFromSource,
 } from "../helpers";
 import { createDynamicStream, createLinearStream } from "../helpers/stream";
@@ -237,12 +236,6 @@ export function handleTransferAdmin(event: EventTransferAdmin): void {
     log.error("[SABLIER]", []);
     return;
   }
-
-  let watcher = getOrCreateWatcher();
-  watcher.logs.push(
-    "Transfer for: ".concat(dataSource.address().toHexString()),
-  );
-  watcher.save();
 
   contract.admin = event.params.newAdmin;
   contract.save();

--- a/packages/protocol/subgraph.template.yaml
+++ b/packages/protocol/subgraph.template.yaml
@@ -1,5 +1,5 @@
 specVersion: 0.0.5
-description: Sablier V2 Subgraph
+description: Sablier V2 Protocol Subgraph
 repository: https://github.com/sablier-labs/v2-subgraphs
 schema:
   file: ./schema.graphql
@@ -48,12 +48,12 @@ templates:
       language: wasm/assemblyscript
       entities:
         - Action
+        - Asset
         - Batch
         - Batcher
         - Contract
         - Segment
         - Stream
-        - Token
         - Watcher
       abis:
         - name: ERC20
@@ -99,12 +99,12 @@ templates:
       language: wasm/assemblyscript
       entities:
         - Action
+        - Asset
         - Contract
         - Batch
         - Batcher
         - Segment
         - Stream
-        - Token
         - Watcher
       abis:
         - name: ERC20

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,6 +790,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sablier/v2-subgraphs-merkle-streamer@workspace:packages/merkle-streamer":
+  version: 0.0.0-use.local
+  resolution: "@sablier/v2-subgraphs-merkle-streamer@workspace:packages/merkle-streamer"
+  dependencies:
+    "@graphprotocol/graph-cli": ^0.55.0
+    "@graphprotocol/graph-ts": ^0.31.0
+    "@trivago/prettier-plugin-sort-imports": 4.1.0
+    "@typescript-eslint/eslint-plugin": ^5.59.11
+    "@typescript-eslint/parser": ^5.59.11
+    babel-polyfill: ^6.26.0
+    babel-register: ^6.26.0
+    eslint: ^8.25.0
+    eslint-config-prettier: ^8.5.0
+    mustache: ^4.2.0
+    prettier: ^2.8.8
+    rimraf: ^3.0.2
+    typescript: 5.1.3
+  languageName: unknown
+  linkType: soft
+
 "@sablier/v2-subgraphs-prb-proxy@workspace:packages/prb-proxy":
   version: 0.0.0-use.local
   resolution: "@sablier/v2-subgraphs-prb-proxy@workspace:packages/prb-proxy"


### PR DESCRIPTION
This PR creates an additional subgraph targeted towards the Merkle Streamer (a.k.a. MS) Sablier V2 feature.
It follows MS **factories** producing contract instances representing **campaigns**. As an extra feature, it attempts to store daily snapshots for claims thus creating a simple set of analytics.