### PR TITLE
refactor: change "expected" wording

### DIFF
--- a/packages/merkle-streamer/schema.graphql
+++ b/packages/merkle-streamer/schema.graphql
@@ -104,9 +104,9 @@ type Campaign @entity {
   "ipfs content identifier for the list of recipients and other static details"
   ipfsCID: String!
   "funds required for the entire campaign to conclude"
-  expectedAmount: BigInt!
-  "number of recipients"
-  expectedRecipients: BigInt!
+  aggregateAmount: BigInt!
+  "total number of recipients"
+  totalRecipients: BigInt!
 
   "action in which the campaign underwent a clawback, if it was supposed to expire"
   clawbackAction: Action

--- a/packages/merkle-streamer/src/helpers/campaign.ts
+++ b/packages/merkle-streamer/src/helpers/campaign.ts
@@ -46,8 +46,8 @@ export function createCampaignLinear(
   entity.expiration = event.params.expiration;
 
   entity.ipfsCID = event.params.ipfsCID;
-  entity.expectedAmount = event.params.aggregateAmount;
-  entity.expectedRecipients = event.params.recipientsCount;
+  entity.aggregateAmount = event.params.aggregateAmount;
+  entity.totalRecipients = event.params.recipientsCount;
 
   entity.category = "LockupLinear";
   entity.streamCliff = !event.params.streamDurations.cliff.isZero();

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,26 +870,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sablier/v2-subgraphs-prb-proxy@workspace:packages/prb-proxy":
-  version: 0.0.0-use.local
-  resolution: "@sablier/v2-subgraphs-prb-proxy@workspace:packages/prb-proxy"
-  dependencies:
-    "@graphprotocol/graph-cli": ^0.60.0
-    "@graphprotocol/graph-ts": ^0.31.0
-    "@trivago/prettier-plugin-sort-imports": 4.1.0
-    "@typescript-eslint/eslint-plugin": ^5.59.11
-    "@typescript-eslint/parser": ^5.59.11
-    babel-polyfill: ^6.26.0
-    babel-register: ^6.26.0
-    eslint: ^8.25.0
-    eslint-config-prettier: ^8.5.0
-    mustache: ^4.2.0
-    prettier: ^2.8.8
-    rimraf: ^3.0.2
-    typescript: 5.1.3
-  languageName: unknown
-  linkType: soft
-
 "@sablier/v2-subgraphs-protocol@workspace:packages/protocol":
   version: 0.0.0-use.local
   resolution: "@sablier/v2-subgraphs-protocol@workspace:packages/protocol"


### PR DESCRIPTION
Implements the feedback left in https://github.com/sablier-labs/v2-subgraphs/discussions/19.

I've gone with `aggregateAmount` because that's the wording used in Solidity + to avoid conflicts with `totalAmount` in V2 Core.