### PR TITLE
Make this indexer work smoothly on linux by adding an npmrc file

### DIFF
--- a/apps/merkle-envio/.npmrc
+++ b/apps/merkle-envio/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true # Without this pnpm has issues resolving some dependencies on linux (Mac seems to be fine)


### PR DESCRIPTION
On Linux with pnpm the indexer is unable to locate some dependencies. I tried many versions of pnpm and got the same result. For some reason this issues doesn't happen on MacOS.

This file is present in `protocol-envio` already.

